### PR TITLE
Using dill instead of pickle if possible

### DIFF
--- a/src/rbfopt/rbfopt_algorithm.py
+++ b/src/rbfopt/rbfopt_algorithm.py
@@ -18,7 +18,10 @@ import sys
 import math
 import time
 import os
-import pickle
+try:
+    import dill as pickle
+except:
+    import pickle
 import copy
 import collections
 import numpy as np


### PR DESCRIPTION
dill can serialize more types than pickle, pickle just fails with errors in these cases.